### PR TITLE
[#28] Search 페이지 레이아웃

### DIFF
--- a/FrontEnd/rebon-frontend/src/App.js
+++ b/FrontEnd/rebon-frontend/src/App.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
 import { createGlobalStyle } from 'styled-components';
-import Begin from './Pages/Begin';
-import Search from './Pages/Search';
+import Router from './Router';
 
 function App() {
   const GlobalStyle = createGlobalStyle`
@@ -72,7 +70,7 @@ a{
   return (
     <>
       <GlobalStyle />
-      <Search />
+      <Router />
     </>
   );
 }

--- a/FrontEnd/rebon-frontend/src/App.js
+++ b/FrontEnd/rebon-frontend/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { createGlobalStyle } from 'styled-components';
 import Begin from './Pages/Begin';
+import Search from './Pages/Search';
 
 function App() {
   const GlobalStyle = createGlobalStyle`
@@ -71,7 +72,7 @@ a{
   return (
     <>
       <GlobalStyle />
-      <Begin />
+      <Search />
     </>
   );
 }

--- a/FrontEnd/rebon-frontend/src/Pages/Begin/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Begin/index.js
@@ -1,7 +1,0 @@
-import Header from '../../Components/Header';
-
-function Begin() {
-  return <Header />;
-}
-
-export default Begin;

--- a/FrontEnd/rebon-frontend/src/Pages/Search/Contents/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/Contents/index.js
@@ -1,0 +1,109 @@
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+
+// 이 콘텐츠 이름은 다른 분들것과 따라 맞추자
+function Contents() {
+  return (
+    <Wrapper>
+      <ContentStyle>
+        <Title>
+          가고 싶은 지역을 입력해서 <br />
+          <span>맛집, 숙소</span>를 찾아보세요!
+        </Title>
+
+        <InputBar>
+          <Input />
+          <FontAwesomeIcon icon={faSearch} className="search" />
+        </InputBar>
+
+        <Tags>
+          <div>추천 태그</div>
+          <Tag>영일대</Tag>
+          <Tag>양덕</Tag>
+          <Tag>구룡포</Tag>
+          <Tag>칠포해수욕장</Tag>
+
+          <Tag>영일대</Tag>
+          <Tag>양덕</Tag>
+          <Tag>구룡포</Tag>
+          <Tag>칠포해수욕장</Tag>
+
+          <Tag>구룡포</Tag>
+          <Tag>칠포해수욕장</Tag>
+        </Tags>
+      </ContentStyle>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 400px;
+  height: 100vh;
+  margin: 0 auto;
+`;
+
+const ContentStyle = styled.div`
+  width: 22vw;
+  display: grid;
+  margin-top: -30px;
+  grid-template-rows: repeat(3, 80px);
+`;
+
+const Title = styled.div`
+  font-weight: 500;
+  font-size: 22px;
+  line-height: 1.2em;
+  span {
+    font-weight: bolder;
+  }
+`;
+
+const InputBar = styled.div`
+  margin-top: 10px;
+  width: 95%;
+  height: 35px;
+  border-radius: 50px;
+  border: 1px solid black;
+`;
+
+const Input = styled.input`
+  padding-left: 10px;
+  width: 90%;
+  height: 35px;
+  border-radius: 50px;
+  background-color: transparent;
+  border: none;
+  &:focus {
+    outline: none;
+  }
+`;
+
+const Tags = styled.ul`
+  font-size: 15px;
+  padding: 0 5px;
+  div {
+    color: rgba(0, 0, 0, 0.3);
+    grid-column: 1 / 5;
+    margin-bottom: 10px;
+  }
+`;
+
+const Tag = styled.li`
+  width: fit-content;
+  padding: 5px 7px;
+  margin: 5px;
+  float: left;
+  border: 1px solid black;
+  border-radius: 50px;
+  font-weight: 500;
+  &:hover {
+    color: white;
+    background-color: black;
+  }
+`;
+
+export default Contents;

--- a/FrontEnd/rebon-frontend/src/Pages/Search/Contents/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/Contents/index.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
-
+import Tags from '../Tags';
 // 이 콘텐츠 이름은 다른 분들것과 따라 맞추자
 function Contents() {
   return (
@@ -17,21 +17,7 @@ function Contents() {
           <FontAwesomeIcon icon={faSearch} className="search" />
         </InputBar>
 
-        <Tags>
-          <div>추천 태그</div>
-          <Tag>영일대</Tag>
-          <Tag>양덕</Tag>
-          <Tag>구룡포</Tag>
-          <Tag>칠포해수욕장</Tag>
-
-          <Tag>영일대</Tag>
-          <Tag>양덕</Tag>
-          <Tag>구룡포</Tag>
-          <Tag>칠포해수욕장</Tag>
-
-          <Tag>구룡포</Tag>
-          <Tag>칠포해수욕장</Tag>
-        </Tags>
+        <Tags />
       </ContentStyle>
     </Wrapper>
   );
@@ -79,30 +65,6 @@ const Input = styled.input`
   border: none;
   &:focus {
     outline: none;
-  }
-`;
-
-const Tags = styled.ul`
-  font-size: 15px;
-  padding: 0 5px;
-  div {
-    color: rgba(0, 0, 0, 0.3);
-    grid-column: 1 / 5;
-    margin-bottom: 10px;
-  }
-`;
-
-const Tag = styled.li`
-  width: fit-content;
-  padding: 5px 7px;
-  margin: 5px;
-  float: left;
-  border: 1px solid black;
-  border-radius: 50px;
-  font-weight: 500;
-  &:hover {
-    color: white;
-    background-color: black;
   }
 `;
 

--- a/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
@@ -4,21 +4,14 @@ function Tags() {
   return (
     <Wrapper>
       <div>추천 태그</div>
-      <Tag>영일대</Tag>
-      <Tag>양덕</Tag>
-      <Tag>구룡포</Tag>
-      <Tag>칠포해수욕장</Tag>
-
-      <Tag>영일대</Tag>
-      <Tag>양덕</Tag>
-      <Tag>구룡포</Tag>
-      <Tag>칠포해수욕장</Tag>
-
-      <Tag>구룡포</Tag>
-      <Tag>칠포해수욕장</Tag>
+      {api.map((tagApi) => (
+        <Tag>{tagApi}</Tag>
+      ))}
     </Wrapper>
   );
 }
+const api = ['영일대', '양덕', '구룡포', '칠포해수욕장', '영일대', '양덕', '구룡포', '칠포해수욕장', '구룡포', '칠포해수욕장'];
+
 const Wrapper = styled.ul`
   font-size: 15px;
   padding: 0 5px;

--- a/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+function Tags() {
+  return (
+    <Wrapper>
+      <div>추천 태그</div>
+      <Tag>영일대</Tag>
+      <Tag>양덕</Tag>
+      <Tag>구룡포</Tag>
+      <Tag>칠포해수욕장</Tag>
+
+      <Tag>영일대</Tag>
+      <Tag>양덕</Tag>
+      <Tag>구룡포</Tag>
+      <Tag>칠포해수욕장</Tag>
+
+      <Tag>구룡포</Tag>
+      <Tag>칠포해수욕장</Tag>
+    </Wrapper>
+  );
+}
+const Wrapper = styled.ul`
+  font-size: 15px;
+  padding: 0 5px;
+  div {
+    color: rgba(0, 0, 0, 0.3);
+    grid-column: 1 / 5;
+    margin-bottom: 10px;
+  }
+`;
+
+const Tag = styled.li`
+  width: fit-content;
+  padding: 5px 7px;
+  margin: 5px;
+  float: left;
+  border: 1px solid black;
+  border-radius: 50px;
+  font-weight: 500;
+  &:hover {
+    color: white;
+    background-color: black;
+  }
+`;
+
+export default Tags;

--- a/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/Tags/index.js
@@ -4,8 +4,8 @@ function Tags() {
   return (
     <Wrapper>
       <div>추천 태그</div>
-      {api.map((tagApi) => (
-        <Tag>{tagApi}</Tag>
+      {api.map((item) => (
+        <Tag>{item}</Tag>
       ))}
     </Wrapper>
   );

--- a/FrontEnd/rebon-frontend/src/Pages/Search/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/index.js
@@ -1,4 +1,11 @@
-import styled from '../../Components/Header';
-function Search() {}
+import Header from '../../Components/Header';
+import Contents from './Contents';
 
-export default Search;
+export default function Search() {
+  return (
+    <>
+      <Header />
+      <Contents />
+    </>
+  );
+}

--- a/FrontEnd/rebon-frontend/src/Pages/Search/index.js
+++ b/FrontEnd/rebon-frontend/src/Pages/Search/index.js
@@ -1,0 +1,4 @@
+import styled from '../../Components/Header';
+function Search() {}
+
+export default Search;

--- a/FrontEnd/rebon-frontend/src/Router.js
+++ b/FrontEnd/rebon-frontend/src/Router.js
@@ -1,0 +1,14 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Search from './Pages/Search';
+
+function Router() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Search />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default Router;


### PR DESCRIPTION
### Description
- SearchPage 제작 위한 Search 폴더 생성
- SearchPage 폴더 아래 Cotents 폴더 생성
- Content 컴포넌트 제작
- Search/Contents에 있던 Tags를 컴포넌트 단위로 분리
- Tags 컴포넌트를 생성하여 api배열을 map으로 받아서 Tag 스타일에 적용시켰다
- Search Page에 라우터를 적용하여 URL로 이동할 수 있도록 하였다.
- npm i react-router-dom
- Search 페이지 레이아웃 완료

### Trouble Shooting


### ETC
