### PR TITLE
[#127]: 리뷰 생성과 인가 기능 연동

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -184,4 +184,35 @@ include::{snippets}/ShopReadAcceptanceTest/showCafeDetail/http-request.adoc[]
 include::{snippets}/ShopReadAcceptanceTest/showCafeDetail/http-response.adoc[]
 
 == Review API
-`구현 후 추가 예정`
+=== 리뷰 생성 로그인이 된 경우
+==== Request
+
+|===
+| 값 | 타입 | 필수 | 설명
+| token | String | true | Authorization header에 bearer type으로 jwt 보내주기
+| shopId | Long | true | Path variable로 리뷰 쓰는 가게 보내주기
+| content | String | true | 리뷰 내용
+| tip | String | false | 팁 내용
+| star | int | true | 리뷰 점수
+| images | List<MultipartFile> | false | 리뷰 사진들
+|===
+include::{snippets}/ReviewCreateAcceptanceTest/createReviewWithLogin/http-request.adoc[]
+
+==== Response
+include::{snippets}/ReviewCreateAcceptanceTest/createReviewWithLogin/http-response.adoc[]
+
+=== 리뷰 생성 로그인이 되지 않은 경우
+==== Request
+
+|===
+| 값 | 타입 | 필수 | 설명
+| shopId | Long | true | Path variable로 리뷰 쓰는 가게 보내주기
+| content | String | true | 리뷰 내용
+| tip | String | false | 팁 내용
+| star | int | true | 리뷰 점수
+| images | List<MultipartFile> | false | 리뷰 사진들
+|===
+include::{snippets}/ReviewCreateAcceptanceTest/createReviewWithoutLogin/http-request.adoc[]
+
+==== Response
+include::{snippets}/ReviewCreateAcceptanceTest/createReviewWithoutLogin/http-response.adoc[]

--- a/backend/src/main/java/com/handong/rebon/member/application/MemberService.java
+++ b/backend/src/main/java/com/handong/rebon/member/application/MemberService.java
@@ -19,7 +19,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
 
-    //Review 메서드가 잘 돌아가는지 확인을 위해 임시로 만든 메서드
     @Transactional(readOnly = true)
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);

--- a/backend/src/main/java/com/handong/rebon/member/presentation/dto/response/MemberCreateResponse.java
+++ b/backend/src/main/java/com/handong/rebon/member/presentation/dto/response/MemberCreateResponse.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberCreateResponse {

--- a/backend/src/main/java/com/handong/rebon/member/presentation/dto/response/MemberCreateResponse.java
+++ b/backend/src/main/java/com/handong/rebon/member/presentation/dto/response/MemberCreateResponse.java
@@ -4,9 +4,13 @@ import com.handong.rebon.member.application.dto.response.MemberCreateResponseDto
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class MemberCreateResponse {
     private String token;
 

--- a/backend/src/main/java/com/handong/rebon/review/application/ReviewService.java
+++ b/backend/src/main/java/com/handong/rebon/review/application/ReviewService.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import com.handong.rebon.exception.member.MemberNotFoundException;
 import com.handong.rebon.exception.review.ReviewNotFoundException;
+import com.handong.rebon.exception.shop.NoSuchShopException;
 import com.handong.rebon.exception.shop.ShopNotFoundException;
-import com.handong.rebon.member.application.MemberService;
 import com.handong.rebon.member.domain.Member;
 import com.handong.rebon.member.domain.repository.MemberRepository;
 import com.handong.rebon.review.application.dto.ReviewDtoAssembler;
@@ -37,17 +37,13 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ShopRepository shopRepository;
-    private final MemberService memberService;
     private final ReviewImageRepository reviewImageRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
     public Long create(ReviewCreateRequestDto reviewCreateRequestDto) {
-        //TODO 멤버 찾아오기
-        Member member = memberService.findById(reviewCreateRequestDto.getMemberId());
-
-        //TODO shop 찾아오기
-        Shop shop = shopRepository.findById(reviewCreateRequestDto.getShopId()).orElseThrow();
+        Member member = getMember(reviewCreateRequestDto.getMemberId());
+        Shop shop = getShop(reviewCreateRequestDto.getShopId());
 
         //TODO 이미지 저장
         ReviewImages reviewImages = saveImages(reviewCreateRequestDto.getImages());
@@ -65,14 +61,13 @@ public class ReviewService {
         return savedReview.getId();
     }
 
-
     @Transactional
     public void delete(ReviewDeleteRequestDto reviewDeleteRequestDto) {
         Long reviewId = reviewDeleteRequestDto.getReviewId();
         Long memberId = reviewDeleteRequestDto.getMemberId();
 
         Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
-        Member member = memberService.findById(memberId);
+        Member member = getMember(memberId);
 
         review.delete(member);
     }
@@ -140,6 +135,16 @@ public class ReviewService {
         reviewImageRepository.save(url2);
 
         return new ReviewImages(Arrays.asList(url1, url2));
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                               .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private Shop getShop(Long shopId) {
+        return shopRepository.findById(shopId)
+                             .orElseThrow(NoSuchShopException::new);
     }
 
 }

--- a/backend/src/main/java/com/handong/rebon/review/application/ReviewService.java
+++ b/backend/src/main/java/com/handong/rebon/review/application/ReviewService.java
@@ -125,7 +125,6 @@ public class ReviewService {
         return ReviewDtoAssembler.adminReviewResponseDto(review);
     }
 
-    //TODO 이미지 저장 기능
     private ReviewImages saveImages(List<String> imageUrls) {
         List<ReviewImage> reviewImages = imageUrls.stream()
                                                   .map(ReviewImage::new)

--- a/backend/src/main/java/com/handong/rebon/review/application/dto/request/ReviewCreateRequestDto.java
+++ b/backend/src/main/java/com/handong/rebon/review/application/dto/request/ReviewCreateRequestDto.java
@@ -1,11 +1,10 @@
 package com.handong.rebon.review.application.dto.request;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.handong.rebon.review.domain.content.ReviewContent;
 import com.handong.rebon.review.domain.content.ReviewScore;
-
-import org.springframework.web.multipart.MultipartFile;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +18,7 @@ public class ReviewCreateRequestDto {
     private Long shopId;
     private String content;
     private String tip;
-    private List<MultipartFile> images;
+    private List<String> imageUrls;
     private int star;
 
     public ReviewContent getReviewContent() {

--- a/backend/src/main/java/com/handong/rebon/review/presentation/ApiReviewController.java
+++ b/backend/src/main/java/com/handong/rebon/review/presentation/ApiReviewController.java
@@ -1,13 +1,16 @@
 package com.handong.rebon.review.presentation;
 
+import java.net.URI;
 import java.util.List;
 
 import com.handong.rebon.auth.domain.Login;
 import com.handong.rebon.auth.domain.LoginMember;
 import com.handong.rebon.auth.domain.RequiredLogin;
 import com.handong.rebon.review.application.ReviewService;
+import com.handong.rebon.review.application.dto.request.ReviewCreateRequestDto;
 import com.handong.rebon.review.application.dto.request.ReviewGetByShopRequestDto;
 import com.handong.rebon.review.application.dto.response.ReviewGetByShopResponseDto;
+import com.handong.rebon.review.presentation.dto.ReviewAssembler;
 import com.handong.rebon.review.presentation.dto.request.ReviewRequest;
 import com.handong.rebon.review.presentation.dto.response.ReviewGetByShopResponse;
 import com.handong.rebon.review.presentation.dto.response.ReviewResponse;
@@ -25,17 +28,18 @@ public class ApiReviewController {
 
     @RequiredLogin
     @PostMapping("/shops/{shopId}/reviews")
-    public ReviewResponse create(
-            //member TODO 유저 구현 후,
+    public ResponseEntity<Void> create(
+            @Login LoginMember loginMember,
             @PathVariable Long shopId,
             @RequestBody ReviewRequest reviewRequest
     ) {
-        /*
-        ReviewCreateRequestDto reviewCreateRequestDto = ReviewAssembler.reviewCreateRequestDto(, shopId, reviewRequest);//TODO user 구현 후 userId 구현해야됨
-        ReviewResponseDto reviewResponseDto = reviewService.create(reviewCreateRequestDto);
-        ReviewAssembler.reviewResponse(reviewResponseDto);
-        */
-        return new ReviewResponse();
+
+        ReviewCreateRequestDto reviewCreateRequestDto = ReviewAssembler.reviewCreateRequestDto(loginMember.getId(), shopId, reviewRequest);
+        Long reviewId = reviewService.create(reviewCreateRequestDto);
+        URI location = URI.create("/api/reviews/" + reviewId);
+
+        return ResponseEntity.created(location)
+                             .build();
     }
 
     @RequiredLogin

--- a/backend/src/main/java/com/handong/rebon/review/presentation/dto/ReviewAssembler.java
+++ b/backend/src/main/java/com/handong/rebon/review/presentation/dto/ReviewAssembler.java
@@ -16,7 +16,7 @@ public class ReviewAssembler {
                                      .content(reviewRequest.getContent())
                                      .tip(reviewRequest.getTip())
                                      .star(reviewRequest.getStar())
-                                     .images(reviewRequest.getImages())
+                                     .imageUrls(reviewRequest.getImageUrls())
                                      .build();
 
     }

--- a/backend/src/main/java/com/handong/rebon/review/presentation/dto/request/ReviewRequest.java
+++ b/backend/src/main/java/com/handong/rebon/review/presentation/dto/request/ReviewRequest.java
@@ -1,8 +1,7 @@
 package com.handong.rebon.review.presentation.dto.request;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.web.multipart.MultipartFile;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +15,12 @@ import lombok.Setter;
 public class ReviewRequest {
     private String content;
     private String tip;
-    private List<MultipartFile> images;
+    private List<String> imageUrls = new ArrayList<>();
     private int star;
+
+    public ReviewRequest(String content, String tip, int star) {
+        this.content = content;
+        this.tip = tip;
+        this.star = star;
+    }
 }

--- a/backend/src/main/java/com/handong/rebon/review/presentation/dto/request/ReviewRequest.java
+++ b/backend/src/main/java/com/handong/rebon/review/presentation/dto/request/ReviewRequest.java
@@ -1,18 +1,21 @@
 package com.handong.rebon.review.presentation.dto.request;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReviewRequest {
     private String content;
     private String tip;
-    private List<MultipartFile> images = new ArrayList<>();
+    private List<MultipartFile> images;
     private int star;
 }

--- a/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
+++ b/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
@@ -98,7 +98,7 @@ public class ShopService {
         shopRepository.delete(shop);
     }
 
-    private Shop findById(Long id) {
+    public Shop findById(Long id) {
         return shopRepository.findById(id)
                              .orElseThrow(NoSuchShopException::new);
     }

--- a/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
@@ -25,7 +25,6 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 
 import static com.handong.rebon.acceptance.AcceptanceUtils.setRequestSpecification;
-import static com.handong.rebon.acceptance.member.MemberCreateAcceptanceTest.saveMember;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;

--- a/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
@@ -1,6 +1,9 @@
 package com.handong.rebon.acceptance;
 
+import com.handong.rebon.acceptance.member.MemberCreateAcceptanceTest;
 import com.handong.rebon.config.InfrastructureTestConfig;
+import com.handong.rebon.member.presentation.dto.request.MemberCreateRequest;
+import com.handong.rebon.member.presentation.dto.response.MemberCreateResponse;
 import com.handong.rebon.util.DatabaseCleaner;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +20,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 
 import static com.handong.rebon.acceptance.AcceptanceUtils.setRequestSpecification;
+import static com.handong.rebon.acceptance.member.MemberCreateAcceptanceTest.saveMember;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
@@ -34,6 +40,7 @@ public class AcceptanceTest {
     public static final String TEST_OAUTH_PROVIDER = "google";
     public static final String TEST_CODE = "test-code";
     public static final String TEST_NICKNAME = "test";
+    public String token;
 
     @LocalServerPort
     private int port;
@@ -53,5 +60,27 @@ public class AcceptanceTest {
                 .build();
         setRequestSpecification(spec);
         cleaner.execute();
+        ExtractableResponse<Response> memberResponse = saveMember();
+        token = extractedToken(memberResponse);
+    }
+
+    private String extractedToken(ExtractableResponse<Response> memberResponse) {
+        MemberCreateResponse memberCreateResponse = memberResponse.body().as(MemberCreateResponse.class);
+        return memberCreateResponse.getToken();
+    }
+
+    private ExtractableResponse<Response> saveMember() {
+        MemberCreateRequest memberCreateRequest = new MemberCreateRequest(
+                "test@gmail.com",
+                "test",
+                TEST_OAUTH_PROVIDER,
+                true
+        );
+        ExtractableResponse<Response> memberResponse = MemberCreateAcceptanceTest.saveMember(memberCreateRequest);
+        return memberResponse;
+    }
+
+    public String getToken() {
+        return token;
     }
 }

--- a/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/AcceptanceTest.java
@@ -39,7 +39,6 @@ public class AcceptanceTest {
     public static final String TEST_OAUTH_PROVIDER = "google";
     public static final String TEST_CODE = "test-code";
     public static final String TEST_NICKNAME = "test";
-    public String token;
 
     @LocalServerPort
     private int port;
@@ -59,16 +58,14 @@ public class AcceptanceTest {
                 .build();
         setRequestSpecification(spec);
         cleaner.execute();
-        ExtractableResponse<Response> memberResponse = saveMember();
-        token = extractedToken(memberResponse);
     }
 
-    private String extractedToken(ExtractableResponse<Response> memberResponse) {
+    public static String extractedToken(ExtractableResponse<Response> memberResponse) {
         MemberCreateResponse memberCreateResponse = memberResponse.body().as(MemberCreateResponse.class);
         return memberCreateResponse.getToken();
     }
 
-    private ExtractableResponse<Response> saveMember() {
+    public static ExtractableResponse<Response> 회원가입() {
         MemberCreateRequest memberCreateRequest = new MemberCreateRequest(
                 "test@gmail.com",
                 "test",
@@ -79,7 +76,4 @@ public class AcceptanceTest {
         return memberResponse;
     }
 
-    public String getToken() {
-        return token;
-    }
 }

--- a/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewAcceptanceTest.java
@@ -1,0 +1,58 @@
+package com.handong.rebon.acceptance.review;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.handong.rebon.acceptance.AcceptanceTest;
+import com.handong.rebon.category.domain.Category;
+import com.handong.rebon.common.admin.AdminCategoryRegister;
+import com.handong.rebon.common.admin.AdminShopRegister;
+import com.handong.rebon.common.admin.AdminTagRegister;
+import com.handong.rebon.shop.domain.Shop;
+import com.handong.rebon.shop.domain.content.ShopImage;
+import com.handong.rebon.shop.domain.content.ShopImages;
+import com.handong.rebon.tag.domain.Tag;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class ReviewAcceptanceTest extends AcceptanceTest {
+    @Autowired
+    private AdminTagRegister adminTagRegister;
+
+    @Autowired
+    private AdminCategoryRegister adminCategoryRegister;
+
+    @Autowired
+    private AdminShopRegister adminShopRegister;
+
+    protected Map<String, Tag> tags = new HashMap<>();
+    protected Map<String, Category> categories = new HashMap<>();
+    protected Map<String, Shop> shops = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        tags = adminTagRegister.register("포항", "한동대");
+        categories = adminCategoryRegister.registerMain("식당", "숙소", "카페");
+        categories.putAll(adminCategoryRegister.registerSubs(categories.get("식당"), "분식", "양식"));
+        initShops();
+    }
+
+    private void initShops() {
+        shops.clear();
+        initRestaurant();
+    }
+
+    private void initRestaurant() {
+        shops.put("팜스발리", adminShopRegister.simpleRegister(
+                "팜스발리",
+                categories.get("식당"),
+                Arrays.asList(categories.get("양식"), categories.get("분식")),
+                Arrays.asList(tags.get("포항"), tags.get("한동대")),
+                new ShopImages(Collections.singletonList(new ShopImage("url1", true)))
+        ));
+    }
+}

--- a/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewCreateAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewCreateAcceptanceTest.java
@@ -1,0 +1,76 @@
+package com.handong.rebon.acceptance.review;
+
+import com.handong.rebon.review.presentation.dto.request.ReviewRequest;
+import com.handong.rebon.shop.domain.Shop;
+
+import org.springframework.http.HttpStatus;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import org.assertj.core.api.Assertions;
+
+import static com.handong.rebon.acceptance.AcceptanceUtils.getRequestSpecification;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class ReviewCreateAcceptanceTest extends ReviewAcceptanceTest {
+
+    @Test
+    @DisplayName("로그인이 되어 있는 상태에서 리뷰를 작성한다.")
+    void createReviewWithLogin() {
+        //given
+        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "필수로 시키자", null, 5);
+        Shop shop = shops.get("팜스발리");
+        String bearerToken = "Bearer " + getToken();
+
+        //when
+        ExtractableResponse<Response> response = saveReview(reviewRequest, shop.getId(), bearerToken);
+
+        //then
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+    }
+
+    @Test
+    @DisplayName("로그인이 되어있지 않은 상태에서 리뷰를 작성하지 못한다.")
+    void createReviewWithoutLogin() {
+        //given
+        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "족발은 필수로 시키자", null, 5);
+        Shop shop = shops.get("팜스발리");
+
+        //when
+        ExtractableResponse<Response> response = saveReviewWithoutToken(reviewRequest, shop.getId());
+
+        //then
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private ExtractableResponse<Response> saveReviewWithoutToken(ReviewRequest reviewRequest, Long shopId) {
+        return RestAssured.given(getRequestSpecification())
+                          .log().all()
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(reviewRequest)
+                          .when()
+                          .post("/api/shops/" + shopId + "/reviews")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    private ExtractableResponse<Response> saveReview(ReviewRequest reviewRequest, Long shopId, String token) {
+        return RestAssured.given(getRequestSpecification())
+                          .log().all()
+                          .header("Authorization", token)
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(reviewRequest)
+                          .when()
+                          .post("/api/shops/" + shopId + "/reviews")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}

--- a/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewCreateAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/review/ReviewCreateAcceptanceTest.java
@@ -28,7 +28,7 @@ public class ReviewCreateAcceptanceTest extends ReviewAcceptanceTest {
         //given
         ExtractableResponse<Response> registerResponse = 회원가입();
         String token = extractedToken(registerResponse);
-        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "필수로 시키자", null, 5);
+        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "필수로 시키자", 5);
         Shop shop = shops.get("팜스발리");
         String bearerToken = "Bearer " + token;
 
@@ -44,7 +44,7 @@ public class ReviewCreateAcceptanceTest extends ReviewAcceptanceTest {
     @DisplayName("로그인이 되어있지 않은 상태에서 리뷰를 작성하지 못한다.")
     void createReviewWithoutLogin() {
         //given
-        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "족발은 필수로 시키자", null, 5);
+        ReviewRequest reviewRequest = new ReviewRequest("맛이 좋아요", "족발은 필수로 시키자", 5);
         Shop shop = shops.get("팜스발리");
 
         //when

--- a/backend/src/test/java/com/handong/rebon/controller/auth/AuthorizationInterceptorTest.java
+++ b/backend/src/test/java/com/handong/rebon/controller/auth/AuthorizationInterceptorTest.java
@@ -1,5 +1,6 @@
 package com.handong.rebon.controller.auth;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -104,7 +105,7 @@ public class AuthorizationInterceptorTest extends ControllerTest {
     }
 
     private void saveReview(Long memberId, Shop shop) {
-        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(memberId, shop.getId(), "테스트 컨텐트", "테스트 팁", null, 4);
+        ReviewCreateRequestDto reviewCreateRequestDto = new ReviewCreateRequestDto(memberId, shop.getId(), "테스트 컨텐트", "테스트 팁", new ArrayList<>(), 4);
         reviewService.create(reviewCreateRequestDto);
     }
 

--- a/backend/src/test/java/com/handong/rebon/integration/review/ReviewIntegrationTest.java
+++ b/backend/src/test/java/com/handong/rebon/integration/review/ReviewIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.handong.rebon.integration.review;
 
+import java.util.ArrayList;
+
 import com.handong.rebon.integration.IntegrationTest;
 import com.handong.rebon.member.domain.Member;
 import com.handong.rebon.member.domain.repository.MemberRepository;
@@ -63,11 +65,12 @@ class ReviewIntegrationTest extends IntegrationTest {
 
     public ReviewRequest createReviewRequest(String content, String tip, int star) {
         ReviewRequest reviewRequest = new ReviewRequest();
+        ArrayList<String> imageUrls = new ArrayList<>();
 
         reviewRequest.setContent(content);
         reviewRequest.setTip(tip);
         reviewRequest.setStar(star);
-        //reviewRequest.setImages();  TODO 이미지 저장 후 구현
+        reviewRequest.setImageUrls(imageUrls);
 
         return reviewRequest;
     }


### PR DESCRIPTION
### Description
- 리뷰 생성과 인가 기능을 연동
- header에 authorization 추가한 것과 추가하지 않은 것에 대한 인수테스트 진행
- review created response에 /api/reviews/{reviewId}로 Location 설정
- review image는 프론트에서 s3에 저장 후, url를 백엔드로 보내기로.
- review image url를 저장하는 것까지 추가

### Trouble Shooting


### ETC
