### PR TITLE
인기 태그 조회 api

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -164,6 +164,14 @@ include::{snippets}/TagElasticSearchAcceptanceTest/chosungSearch/http-request.ad
 ==== Response
 include::{snippets}/TagElasticSearchAcceptanceTest/chosungSearch/http-response.adoc[]
 
+=== 인기 검색어 상위 8개 조회 api
+
+==== Request
+include::{snippets}/TagReadAcceptanceTest/getTopTags/http-request.adoc[]
+
+==== Response
+include::{snippets}/TagReadAcceptanceTest/getTopTags/http-response.adoc[]
+
 == Category API
 === 모든 Category 상세 조회
 Root Category 와 그 자식 카테고리들의 배열

--- a/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
+++ b/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
@@ -68,9 +68,10 @@ public class ShopService {
         return ShopImages.of(shopImages);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<ShopSimpleResponseDto> search(ShopSearchDto shopSearchDto) {
         Tag tag = tagService.findById(shopSearchDto.getTag());
+        tag.countUp();
 
         Category category = categoryService.findById(shopSearchDto.getCategory());
         List<Category> subs = categoryService.findAllContainIds(shopSearchDto.getSubCategories());

--- a/backend/src/main/java/com/handong/rebon/tag/application/TagService.java
+++ b/backend/src/main/java/com/handong/rebon/tag/application/TagService.java
@@ -71,4 +71,12 @@ public class TagService {
                                   .map(TagResponseDto::from)
                                   .collect(Collectors.toList());
     }
+
+    @Transactional(readOnly = true)
+    public List<TagResponseDto> findTopTags() {
+        List<Tag> tags = tagRepository.findTop8ByOrderByCountDesc();
+        return tags.stream()
+                   .map(TagResponseDto::from)
+                   .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/application/dto/TagDtoAssembler.java
+++ b/backend/src/main/java/com/handong/rebon/tag/application/dto/TagDtoAssembler.java
@@ -15,7 +15,7 @@ public class TagDtoAssembler {
 
     public static List<TagResponseDto> tagResponseDtos(List<Tag> tags) {
         return tags.stream()
-                   .map(tag -> new TagResponseDto(tag.getId(), tag.getName()))
+                   .map(tag -> new TagResponseDto(tag.getId(), tag.getName(), tag.getCount()))
                    .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/application/dto/response/TagResponseDto.java
+++ b/backend/src/main/java/com/handong/rebon/tag/application/dto/response/TagResponseDto.java
@@ -10,8 +10,9 @@ import lombok.Getter;
 public class TagResponseDto {
     private Long id;
     private String name;
+    private int count;
 
     public static TagResponseDto from(Tag tag) {
-        return new TagResponseDto(tag.getId(), tag.getName());
+        return new TagResponseDto(tag.getId(), tag.getName(), tag.getCount());
     }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/domain/Tag.java
+++ b/backend/src/main/java/com/handong/rebon/tag/domain/Tag.java
@@ -38,6 +38,8 @@ public class Tag extends BaseEntity {
     @OneToMany(mappedBy = "tag")
     private List<ShopTag> shopTags = new ArrayList<>();
 
+    private int count;
+
     public Tag(String name) {
         this.validateBlankName(name);
         this.name = name;
@@ -56,5 +58,9 @@ public class Tag extends BaseEntity {
 
     public void deleteShopTag() {
         this.shopTags.forEach(ShopTag::delete);
+    }
+
+    public void countUp() {
+        this.count++;
     }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/domain/repository/TagRepository.java
+++ b/backend/src/main/java/com/handong/rebon/tag/domain/repository/TagRepository.java
@@ -1,9 +1,13 @@
 package com.handong.rebon.tag.domain.repository;
 
+import java.util.List;
+
 import com.handong.rebon.tag.domain.Tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     boolean existsByName(String name);
+
+    List<Tag> findTop8ByOrderByCountDesc();
 }

--- a/backend/src/main/java/com/handong/rebon/tag/presentation/ApiTagController.java
+++ b/backend/src/main/java/com/handong/rebon/tag/presentation/ApiTagController.java
@@ -40,4 +40,11 @@ public class ApiTagController {
                                              .collect(Collectors.toList());
         return ResponseEntity.ok(result);
     }
+
+    @GetMapping("/tags/top")
+    public ResponseEntity<List<TagResponse>> topTags() {
+        List<TagResponseDto> tagDtos = tagService.findTopTags();
+        List<TagResponse> responses = TagAssembler.tagResponses(tagDtos);
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/presentation/dto/TagAssembler.java
+++ b/backend/src/main/java/com/handong/rebon/tag/presentation/dto/TagAssembler.java
@@ -14,7 +14,7 @@ public class TagAssembler {
 
     public static List<TagResponse> tagResponses(List<TagResponseDto> tags) {
         return tags.stream()
-                   .map(tag -> new TagResponse(tag.getId(), tag.getName()))
+                   .map(tag -> new TagResponse(tag.getId(), tag.getName(), tag.getCount()))
                    .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/handong/rebon/tag/presentation/dto/response/TagResponse.java
+++ b/backend/src/main/java/com/handong/rebon/tag/presentation/dto/response/TagResponse.java
@@ -12,8 +12,9 @@ import lombok.NoArgsConstructor;
 public class TagResponse {
     private Long id;
     private String name;
+    private int count;
 
     public static TagResponse from(TagResponseDto tagResponseDto) {
-        return new TagResponse(tagResponseDto.getId(), tagResponseDto.getName());
+        return new TagResponse(tagResponseDto.getId(), tagResponseDto.getName(), tagResponseDto.getCount());
     }
 }

--- a/backend/src/test/java/com/handong/rebon/acceptance/shop/ShopReadAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/shop/ShopReadAcceptanceTest.java
@@ -31,7 +31,7 @@ import static com.handong.rebon.acceptance.AcceptanceUtils.getRequestSpecificati
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-class ShopReadAcceptanceTest extends AcceptanceTest {
+public class ShopReadAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private AdminTagRegister adminTagRegister;
@@ -169,7 +169,7 @@ class ShopReadAcceptanceTest extends AcceptanceTest {
         assertThat(result.getMessage()).isEqualTo("존재하지 않는 가게입니다.");
     }
 
-    private ExtractableResponse<Response> 가게_리스트_조회_요청(Long tag, Long category, List<Long> subs) {
+    public static ExtractableResponse<Response> 가게_리스트_조회_요청(Long tag, Long category, List<Long> subs) {
         return RestAssured.given(getRequestSpecification())
                           .log().all()
                           .contentType(APPLICATION_JSON_VALUE)

--- a/backend/src/test/java/com/handong/rebon/acceptance/tag/TagReadAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/tag/TagReadAcceptanceTest.java
@@ -5,7 +5,11 @@ import java.util.List;
 import java.util.Map;
 
 import com.handong.rebon.acceptance.AcceptanceTest;
+import com.handong.rebon.category.domain.Category;
+import com.handong.rebon.common.admin.AdminCategoryRegister;
+import com.handong.rebon.common.admin.AdminShopRegister;
 import com.handong.rebon.common.admin.AdminTagRegister;
+import com.handong.rebon.shop.domain.Shop;
 import com.handong.rebon.tag.domain.Tag;
 import com.handong.rebon.tag.presentation.dto.response.TagResponse;
 
@@ -22,17 +26,30 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 import static com.handong.rebon.acceptance.AcceptanceUtils.getRequestSpecification;
+import static com.handong.rebon.acceptance.shop.ShopReadAcceptanceTest.가게_리스트_조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TagReadAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private AdminTagRegister adminTagRegister;
+
+    @Autowired
+    private AdminCategoryRegister adminCategoryRegister;
+
+    @Autowired
+    private AdminShopRegister adminShopRegister;
+
     private Map<String, Tag> tags = new HashMap<>();
+    private Map<String, Category> categories = new HashMap<>();
+    private Map<String, Shop> shops = new HashMap<>();
 
     @BeforeEach
     void setUp() {
         tags = adminTagRegister.register("북구", "남구", "흥해읍", "양덕동");
+        categories = adminCategoryRegister.registerMain("식당", "숙소", "카페");
+        categories.putAll(adminCategoryRegister.registerSubs(categories.get("식당"), "한식", "분식", "일식", "양식"));
+        categories.putAll(adminCategoryRegister.registerSubs(categories.get("카페"), "프랜차이즈", "개인카페"));
     }
 
     @Test
@@ -52,11 +69,56 @@ public class TagReadAcceptanceTest extends AcceptanceTest {
                 .contains("북구", "남구", "흥해읍", "양덕동");
     }
 
+    @Test
+    @DisplayName("인기 태그 조회")
+    void getTopTags() {
+        // given
+        Tag 북구 = tags.get("북구");
+        Tag 남구 = tags.get("남구");
+        Tag 흥해읍 = tags.get("흥해읍");
+        Tag 양덕동 = tags.get("양덕동");
+        Category 식당 = categories.get("식당");
+        Category 한식 = categories.get("한식");
+
+        가게_리스트_조회_요청(북구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(북구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(북구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(북구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(남구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(남구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(남구.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(흥해읍.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(흥해읍.getId(), 식당.getId(), List.of(한식.getId()));
+        가게_리스트_조회_요청(양덕동.getId(), 식당.getId(), List.of(한식.getId()));
+
+        // when
+        ExtractableResponse<Response> response = 인기_태그_조회();
+        List<TagResponse> result = response.as(new TypeRef<>() {
+        });
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.get(0)).extracting("name").isEqualTo(북구.getName());
+        assertThat(result.get(1)).extracting("name").isEqualTo(남구.getName());
+        assertThat(result.get(2)).extracting("name").isEqualTo(흥해읍.getName());
+        assertThat(result.get(3)).extracting("name").isEqualTo(양덕동.getName());
+    }
+
     private ExtractableResponse<Response> 태그_조회_요청() {
         return RestAssured.given(getRequestSpecification())
                           .log().all()
                           .when()
                           .get("/api/tags")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    private ExtractableResponse<Response> 인기_태그_조회() {
+        return RestAssured.given(getRequestSpecification())
+                          .log().all()
+                          .when()
+                          .get("/api/tags/top")
                           .then()
                           .log().all()
                           .extract();


### PR DESCRIPTION
### Description
사람들이 가장 많이 검색한 태그 조회 api 기능 구현
- 상위 8개의 태그만 반환
- 태그 자체는 실제 shop 목록을 검색할때 같이 카운트 수를 늘리는 식으로 구현

### Trouble Shooting
- shop search메서드에 @Transactional(readOnly=true)가 있었어서 count++ 작업이 정상동작하지 않음.
- 원래 update 작업이 있으면 예외를 던져주는 것으로 알고있었는데 명시적으로 repository에 저장하지 않고 객체에서만 ++해줘서 그런지 예외가 발생하지 않고 update 쿼리가 나가지 않아서 바로 파악하지 못했었음
- readOnly 옵션을 제거해줌

### ETC
