### PR TITLE
LazyInitializationException 예외 발생 문제 해결

### DIFF
--- a/backend/src/test/java/com/handong/rebon/controller/ControllerTest.java
+++ b/backend/src/test/java/com/handong/rebon/controller/ControllerTest.java
@@ -8,6 +8,7 @@ import com.handong.rebon.config.InfrastructureTestConfig;
 import com.handong.rebon.config.NotUseElasticSearchConfig;
 import com.handong.rebon.member.application.MemberService;
 import com.handong.rebon.review.application.ReviewService;
+import com.handong.rebon.shop.application.ShopService;
 import com.handong.rebon.tag.application.TagService;
 import com.handong.rebon.tag.domain.repository.TagSearchRepository;
 import com.handong.rebon.util.DatabaseCleaner;
@@ -44,6 +45,9 @@ public class ControllerTest {
 
     @Autowired
     protected CategoryService categoryService;
+
+    @Autowired
+    protected ShopService shopService;
 
     @Autowired
     protected TagService tagService;


### PR DESCRIPTION
### Description
`GET /api/shops/{shopId}/reviews - 적절한 토큰` 테스트에서 발생하는 오류 해결 

### Trouble Shooting 

기존에 테스트 코드 내에서 존재하는 saveShop메서드에서 addCategory 메서드를 호출하는데 addCategory 메서드의 경우 레이지 로딩이 발생하는데, 트랜젝션 밖에서 해당 메서드가 불렸기 때문에 `org.hibernate.LazyInitializationException` 이 발생함. 따라서 shop을 저장하는 로직을 shopService에 내의 존재하는 메서드를 통해(transaction이 걸려있음) 생성함으로써 해당 테스트도 잘 돌아가도록 구현 

https://www.inflearn.com/questions/33949