### PR TITLE
네이버 가게 등록 api로 변경

### DIFF
--- a/backend/src/docs/asciidoc/api.adoc
+++ b/backend/src/docs/asciidoc/api.adoc
@@ -235,6 +235,25 @@ include::{snippets}/CategoryReadAcceptanceTest/getAllRootAndChildrent/http-respo
 
 == Shop API
 
+=== Naver Shop 등록
+==== Request
+|===
+| 값 | 타입 | 필수 | 설명
+
+| keyword | String | true | 검색할 지역(ex. 포항, 구룡포)
+| displayCount | int | true | 한 번에 등록할 가게 수(ex. 10인 경우 -> 식당 10, 카페 10, 숙소 10)
+| page | int | false | 검색할 페이지 수
+|===
+
+include::{snippets}/NaverShopInsertAcceptanceTest/naverShopInsert/http-request.adoc[]
+
+==== Response
+===== 성공
+include::{snippets}/NaverShopInsertAcceptanceTest/naverShopInsert/http-response.adoc[]
+
+===== 없는 페이지
+include::{snippets}/NaverShopInsertAcceptanceTest/naverShopInsertNotExist/http-response.adoc[]
+
 === Shop 리스트 조회(지역, 카테고리 별)
 ==== Request
 |===

--- a/backend/src/main/java/com/handong/rebon/common/DataInitializer.java
+++ b/backend/src/main/java/com/handong/rebon/common/DataInitializer.java
@@ -1,22 +1,10 @@
 package com.handong.rebon.common;
 
-import java.util.*;
+import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.handong.rebon.category.domain.Category;
 import com.handong.rebon.category.domain.repository.CategoryRepository;
-import com.handong.rebon.shop.application.ShopAdapterService;
-import com.handong.rebon.shop.application.adapter.ShopServiceAdapter;
-import com.handong.rebon.shop.domain.Shop;
-import com.handong.rebon.shop.domain.content.ShopImage;
-import com.handong.rebon.shop.domain.content.ShopImages;
-import com.handong.rebon.shop.domain.repository.ShopRepository;
-import com.handong.rebon.shop.infrastructure.NaverShopInserter;
-import com.handong.rebon.shop.infrastructure.dto.NaverShopDto;
-import com.handong.rebon.tag.domain.Tag;
-import com.handong.rebon.tag.domain.repository.TagRepository;
-import com.handong.rebon.tag.domain.repository.TagSearchRepository;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -26,21 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import static com.handong.rebon.util.StringUtil.validatesEmptyList;
-
 @RequiredArgsConstructor
 @Component
 @Profile("prod")
 public class DataInitializer implements ApplicationRunner {
     public static Pattern HOUR_PATTERN = Pattern.compile("([0-9]+:[0-9]+~[0-9]+:[0-9]+)");
-    private static List<String> INIT_QUERY = List.of("포항", "포항 양덕", "구룡포", "한동대");
 
-    private final TagRepository tagRepository;
-    private final TagSearchRepository tagSearchRepository;
     private final CategoryRepository categoryRepository;
-    private final ShopRepository shopRepository;
-    private final ShopAdapterService shopAdapterService;
-    private final NaverShopInserter shopInserter;
 
     @Transactional
     @Override
@@ -49,113 +29,5 @@ public class DataInitializer implements ApplicationRunner {
         Category 카페 = new Category("카페");
         Category 숙소 = new Category("숙소");
         categoryRepository.saveAll(List.of(식당, 카페, 숙소));
-
-        List<Shop> shops = new ArrayList<>();
-        for (String query : INIT_QUERY) {
-            List<NaverShopDto> restaurants = shopInserter.getShops(식당, query, "식당");
-            List<NaverShopDto> cafes = shopInserter.getShops(카페, query, "카페");
-            List<NaverShopDto> lodgings = shopInserter.getShops(숙소, query, "숙소");
-            //                        List<NaverShopDto> restaurants = shopInserter.getShopsWebClient(식당, query, "식당");
-            //                        List<NaverShopDto> cafes = shopInserter.getShopsWebClient(카페, query, "카페");
-            //                        List<NaverShopDto> lodgings = shopInserter.getShopsWebClient(숙소, query, "숙소");
-            shops.addAll(getShops(restaurants, cafes, lodgings));
-        }
-
-        List<Shop> results = new ArrayList<>();
-        for (Shop newShop : shops) {
-            Optional<Shop> shop = shopRepository.findByNaverId(newShop.getNaverId());
-
-            if (shop.isEmpty()) {
-                results.add(newShop);
-                continue;
-            }
-
-            Shop existingShop = shop.get();
-            List<Tag> tags = newShop.getTags();
-            List<Category> categories = newShop.getSubcategories();
-            existingShop.updateTags(tags);
-            existingShop.updateCategories(existingShop.getCategory(), categories);
-        }
-
-        shopRepository.saveAll(results);
-    }
-
-    private List<Shop> getShops(List<NaverShopDto>... shops) {
-        return Arrays.stream(shops)
-                     .flatMap(Collection::stream)
-                     .map(NaverShopDto::getAllShops)
-                     .flatMap(Collection::stream)
-                     .filter(dto -> validatesEmptyList(dto.getShortAddress()))
-                     .filter(dto -> containKeyword(dto.getShortAddress(), "포항"))
-                     .map(dto -> {
-                         Category category = dto.getMainCategory();
-                         List<Category> subCategories = getSubCategories(category, dto.getCategory());
-                         List<Tag> tags = getTags(dto.getTagCandidates());
-                         ShopImages shopImages = new ShopImages(List.of(new ShopImage(dto.getThumUrl(), true)));
-
-                         ShopServiceAdapter adapter = shopAdapterService.shopAdapterByCategory(category);
-                         Shop shop = adapter.createNaverShop(shopImages, dto);
-
-                         shop.addTags(tags);
-                         shop.addCategories(category, subCategories);
-
-                         return shop;
-                     }).collect(Collectors.toList());
-    }
-
-    private boolean containKeyword(List<String> address, String keyword) {
-        String basicAddress = address.get(0);
-        return basicAddress.contains("포항");
-    }
-
-    //    private boolean validatesAddress(List<String> address) {
-    //        if (Objects.isNull(address) || address.isEmpty()) {
-    //            return false;
-    //        }
-    //        String basicAddress = address.get(0);
-    //        return basicAddress.contains("포항");
-    //    }
-
-    private List<Tag> getTags(String address) {
-        List<Tag> tags = new ArrayList<>();
-
-        String[] addressUnits = address.split(" ");
-        for (String name : addressUnits) {
-            Optional<Tag> tag = tagRepository.findByName(name);
-
-            if (tag.isEmpty()) {
-                Tag newTag = tagRepository.save(new Tag(name));
-                tagSearchRepository.save(newTag);
-                tags.add(newTag);
-                continue;
-            }
-
-            tags.add(tag.get());
-        }
-
-        return tags;
-    }
-
-    private List<Category> getSubCategories(Category mainCategory, List<String> categories) {
-        List<Category> subCategories = new ArrayList<>();
-        if (Objects.isNull(categories) || categories.isEmpty()) {
-            return subCategories;
-        }
-
-        categories.stream()
-                  .map(s -> s.split(","))
-                  .flatMap(Arrays::stream)
-                  .forEach(name -> {
-                      Optional<Category> category = categoryRepository.findByName(name);
-
-                      if (category.isEmpty()) {
-                          Category newCategory = categoryRepository.save(new Category(name, mainCategory));
-                          subCategories.add(newCategory);
-                      } else {
-                          subCategories.add(category.get());
-                      }
-                  });
-
-        return subCategories;
     }
 }

--- a/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
+++ b/backend/src/main/java/com/handong/rebon/shop/application/ShopService.java
@@ -1,6 +1,8 @@
 package com.handong.rebon.shop.application;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.handong.rebon.auth.domain.LoginMember;
@@ -24,6 +26,8 @@ import com.handong.rebon.shop.domain.content.ShopImage;
 import com.handong.rebon.shop.domain.content.ShopImages;
 import com.handong.rebon.shop.domain.repository.ShopImageRepository;
 import com.handong.rebon.shop.domain.repository.ShopRepository;
+import com.handong.rebon.shop.infrastructure.NaverShopInserter;
+import com.handong.rebon.shop.infrastructure.dto.NaverShopDto;
 import com.handong.rebon.tag.application.TagService;
 import com.handong.rebon.tag.domain.Tag;
 
@@ -34,9 +38,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
+import static com.handong.rebon.util.StringUtil.validatesEmptyList;
+
 @RequiredArgsConstructor
 @Service
 public class ShopService {
+    private static final List<String> TYPES = List.of("식당", "카페", "숙소");
 
     private final CategoryService categoryService;
     private final TagService tagService;
@@ -45,6 +52,7 @@ public class ShopService {
     private final ShopRepository shopRepository;
     private final ImageUploader imageUploader;
     private final ShopImageRepository shopImageRepository;
+    private final NaverShopInserter shopInserter;
 
     @Transactional
     public Long create(ShopRequestDto shopRequestDto) {
@@ -182,5 +190,60 @@ public class ShopService {
     public boolean isLike(Long id, LoginMember loginMember) {
         Shop shop = findById(id);
         return shop.containLike(loginMember);
+    }
+
+    public void createNaverShops(String keyword, int displayCount, int page) {
+        List<Shop> shops = new ArrayList<>();
+
+        for (String name : TYPES) {
+            Category category = categoryService.findByName(name);
+            NaverShopDto naverShop = shopInserter.getShop(keyword, name, page, displayCount);
+            naverShop.setBasicData(category, keyword);
+            List<Shop> shop = toShop(naverShop);
+            shops.addAll(shop);
+        }
+
+        List<Shop> results = new ArrayList<>();
+        for (Shop newShop : shops) {
+            Optional<Shop> shop = shopRepository.findByNaverId(newShop.getNaverId());
+
+            if (shop.isEmpty()) {
+                results.add(newShop);
+                continue;
+            }
+
+            Shop existingShop = shop.get();
+            List<Tag> tags = newShop.getTags();
+            List<Category> categories = newShop.getSubcategories();
+            existingShop.updateTags(tags);
+            existingShop.updateCategories(existingShop.getCategory(), categories);
+        }
+
+        shopRepository.saveAll(results);
+    }
+
+    private List<Shop> toShop(NaverShopDto naverShop) {
+        return naverShop.getAllShops().stream()
+                        .filter(dto -> validatesEmptyList(dto.getShortAddress()))
+                        .filter(dto -> containKeyword(dto.getShortAddress(), "포항"))
+                        .map(dto -> {
+                            Category category = dto.getMainCategory();
+                            List<Category> subCategories = categoryService.getSubCategories(category, dto.getCategory());
+                            List<Tag> tags = tagService.getTags(dto.getTagCandidates());
+                            ShopImages shopImages = new ShopImages(List.of(new ShopImage(dto.getThumUrl(), true)));
+
+                            ShopServiceAdapter adapter = shopAdapterService.shopAdapterByCategory(category);
+                            Shop shop = adapter.createNaverShop(shopImages, dto);
+
+                            shop.addTags(tags);
+                            shop.addCategories(category, subCategories);
+
+                            return shop;
+                        }).collect(Collectors.toList());
+    }
+
+    private boolean containKeyword(List<String> address, String keyword) {
+        String basicAddress = address.get(0);
+        return basicAddress.contains(keyword);
     }
 }

--- a/backend/src/main/java/com/handong/rebon/shop/infrastructure/NaverShopInserter.java
+++ b/backend/src/main/java/com/handong/rebon/shop/infrastructure/NaverShopInserter.java
@@ -1,7 +1,5 @@
 package com.handong.rebon.shop.infrastructure;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -31,8 +29,8 @@ public class NaverShopInserter {
     }
 
     public NaverShopDto getShop(String query, String condition, int page, int displayCount) {
-//        String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s&type=all&displayCount=%d&lang=ko&page=%d",
-//                URLEncoder.encode(query + " " + condition, StandardCharsets.UTF_8), displayCount, page);
+        //        String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s&type=all&displayCount=%d&lang=ko&page=%d",
+        //                URLEncoder.encode(query + " " + condition, StandardCharsets.UTF_8), displayCount, page);
         String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s&type=all&displayCount=%d&lang=ko&page=%d",
                 query + " " + condition, displayCount, page);
         ResponseEntity<NaverShopDto> response = restTemplate.getForEntity(url, NaverShopDto.class);

--- a/backend/src/main/java/com/handong/rebon/shop/infrastructure/NaverShopInserter.java
+++ b/backend/src/main/java/com/handong/rebon/shop/infrastructure/NaverShopInserter.java
@@ -1,5 +1,7 @@
 package com.handong.rebon.shop.infrastructure;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -28,30 +30,11 @@ public class NaverShopInserter {
         this.restTemplate = restTemplate;
     }
 
-    public List<NaverShopDto> getShops(Category category, String query, String condition) {
-        List<NaverShopDto> results = new ArrayList<>();
-        int displayCount = 10;
-
-        NaverShopDto shopDto = getShop(query, condition, 1, displayCount);
-        results.add(shopDto);
-
-        int pageCount = (int) Math.ceil((double) shopDto.getTotalCount() / displayCount);
-        if (pageCount > TOTAL_COUNT / displayCount) {
-            pageCount = 31;
-        }
-
-        for (int page = 2; page <= pageCount; page++) {
-            NaverShopDto result = getShop(query, condition, page, displayCount);
-            results.add(result);
-        }
-
-        results.forEach(dto -> dto.setBasicData(category, query));
-
-        return new ArrayList<>(results);
-    }
-
-    private NaverShopDto getShop(String query, String condition, int page, int displayCount) {
-        String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s %s&type=all&displayCount=%d&lang=ko&page=%d", query, condition, displayCount, page);
+    public NaverShopDto getShop(String query, String condition, int page, int displayCount) {
+//        String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s&type=all&displayCount=%d&lang=ko&page=%d",
+//                URLEncoder.encode(query + " " + condition, StandardCharsets.UTF_8), displayCount, page);
+        String url = String.format("https://map.naver.com/v5/api/search?caller=pcweb&query=%s&type=all&displayCount=%d&lang=ko&page=%d",
+                query + " " + condition, displayCount, page);
         ResponseEntity<NaverShopDto> response = restTemplate.getForEntity(url, NaverShopDto.class);
         return response.getBody();
     }

--- a/backend/src/main/java/com/handong/rebon/shop/presentation/ApiShopController.java
+++ b/backend/src/main/java/com/handong/rebon/shop/presentation/ApiShopController.java
@@ -11,6 +11,7 @@ import com.handong.rebon.shop.application.dto.request.ShopSearchDto;
 import com.handong.rebon.shop.application.dto.response.ShopLikeResponseDto;
 import com.handong.rebon.shop.application.dto.response.ShopResponseDto;
 import com.handong.rebon.shop.application.dto.response.ShopSimpleResponseDto;
+import com.handong.rebon.shop.presentation.dto.request.NaverShopRequest;
 import com.handong.rebon.shop.presentation.dto.request.ShopSearchRequest;
 import com.handong.rebon.shop.presentation.dto.response.ShopLikeResponse;
 import com.handong.rebon.shop.presentation.dto.response.ShopResponse;
@@ -73,5 +74,11 @@ public class ApiShopController {
         ShopLikeRequestDto shopLikeRequestDto = new ShopLikeRequestDto(loginMember.getId(), shopId);
         ShopLikeResponseDto shopLikeResponseDto = shopService.unlike(shopLikeRequestDto);
         return ResponseEntity.ok(ShopLikeResponse.from(shopLikeResponseDto));
+    }
+
+    @PostMapping("/shops/naver")
+    public ResponseEntity<Void> naverShops(@RequestBody NaverShopRequest shopRequest) {
+        shopService.createNaverShops(shopRequest.getKeyword(), shopRequest.getDisplayCount(), shopRequest.getPage());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/handong/rebon/shop/presentation/dto/request/NaverShopRequest.java
+++ b/backend/src/main/java/com/handong/rebon/shop/presentation/dto/request/NaverShopRequest.java
@@ -1,0 +1,12 @@
+package com.handong.rebon.shop.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NaverShopRequest {
+    private String keyword;
+    private int displayCount;
+    private int page;
+}

--- a/backend/src/main/java/com/handong/rebon/shop/presentation/dto/request/NaverShopRequest.java
+++ b/backend/src/main/java/com/handong/rebon/shop/presentation/dto/request/NaverShopRequest.java
@@ -1,10 +1,12 @@
 package com.handong.rebon.shop.presentation.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class NaverShopRequest {
     private String keyword;
     private int displayCount;

--- a/backend/src/main/java/com/handong/rebon/tag/application/TagService.java
+++ b/backend/src/main/java/com/handong/rebon/tag/application/TagService.java
@@ -1,6 +1,8 @@
 package com.handong.rebon.tag.application;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.handong.rebon.exception.tag.NoSuchTagException;
@@ -90,5 +92,26 @@ public class TagService {
         return tags.stream()
                    .map(TagResponseDto::from)
                    .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<Tag> getTags(String address) {
+        List<Tag> tags = new ArrayList<>();
+
+        String[] addressUnits = address.split(" ");
+        for (String name : addressUnits) {
+            Optional<Tag> tag = tagRepository.findByName(name);
+
+            if (tag.isEmpty()) {
+                Tag newTag = tagRepository.save(new Tag(name));
+                tagSearchRepository.save(newTag);
+                tags.add(newTag);
+                continue;
+            }
+
+            tags.add(tag.get());
+        }
+
+        return tags;
     }
 }

--- a/backend/src/test/java/com/handong/rebon/acceptance/shop/NaverShopInsertAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/shop/NaverShopInsertAcceptanceTest.java
@@ -1,0 +1,70 @@
+package com.handong.rebon.acceptance.shop;
+
+import com.handong.rebon.acceptance.AcceptanceTest;
+import com.handong.rebon.common.admin.AdminCategoryRegister;
+import com.handong.rebon.shop.presentation.dto.request.NaverShopRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import org.assertj.core.api.Assertions;
+
+import static com.handong.rebon.acceptance.AcceptanceUtils.getRequestSpecification;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+public class NaverShopInsertAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    private AdminCategoryRegister adminCategoryRegister;
+
+    @BeforeEach
+    void setUp() {
+        adminCategoryRegister.registerMain("식당", "숙소", "카페");
+    }
+
+    @Test
+    @DisplayName("네이버 가게 등록")
+    void naverShopInsert() {
+        // given
+        NaverShopRequest shopRequest = new NaverShopRequest("포항", 10, 1);
+
+        // when
+        ExtractableResponse<Response> response = 네이버_가게_등록(shopRequest);
+
+        // then
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("네이버 가게 등록 - 없는 페이지")
+    void naverShopInsertNotExist() {
+        // given
+        NaverShopRequest shopRequest = new NaverShopRequest("포항", 10, 100);
+
+        // when
+        ExtractableResponse<Response> response = 네이버_가게_등록(shopRequest);
+
+        // then
+        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    private ExtractableResponse<Response> 네이버_가게_등록(NaverShopRequest naverShopRequest) {
+        return RestAssured.given(getRequestSpecification())
+                          .log().all()
+                          .contentType(APPLICATION_JSON_VALUE)
+                          .body(naverShopRequest)
+                          .when()
+                          .post("/api/shops/naver")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}


### PR DESCRIPTION
### Description
기존에는 애플리케이션 실행시 자동으로 네이버에 호출하여 가게를 등록함.
배포환경에서 제대로 동작하지 않는 문제 발생
api로 만들어서 동작하도록 변경

### Trouble Shooting
애플리케이션 실행시 자동으로 네이버에 호출하여 가게를 등록하게 했을 때 인코딩을 해주지 않으면 제대로 동작하지 않음.(api는 제대로 동작함..)
배포환경(ubuntu)에서 요청이 제대로 가지 않음. 503에러 발생.(api로 바꾸니 성공률이 많이 올라감. 요청을 한 번에 너무 많이 보내지 않고 하나씩 보내게해서 그런거 같음.)

제대로 동작하지 않는 이유를 모르겠음.
추측: 요청을 여러 페이지 한꺼번에 보내지 않고 하나씩 보내다보니 성공확률이 높아진 것 같음. api로 보내더라도 가끔 요청 실패하는 경우 발생하긴 함.

### ETC
