### PR TITLE
닉네임 중복 체크 항상 200OK 보내는 문제 해결

### DIFF
--- a/backend/src/main/java/com/handong/rebon/config/WebConfig.java
+++ b/backend/src/main/java/com/handong/rebon/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedMethods("*")
-                .allowedOrigins("http://rebon.s3-website.ap-northeast-2.amazonaws.com/", "http://localhost:8080");
+                .allowedOrigins("http://rebon.s3-website.ap-northeast-2.amazonaws.com/", "http://localhost:3000", "http://localhost:8080");
     }
 
     @Override

--- a/backend/src/main/java/com/handong/rebon/member/presentation/ApiMemberController.java
+++ b/backend/src/main/java/com/handong/rebon/member/presentation/ApiMemberController.java
@@ -10,6 +10,7 @@ import com.handong.rebon.member.application.dto.request.MemberUpdateRequestDto;
 import com.handong.rebon.member.application.dto.response.MemberCreateResponseDto;
 import com.handong.rebon.member.application.dto.response.MemberReadResponseDto;
 import com.handong.rebon.member.presentation.dto.MemberAssembler;
+import com.handong.rebon.member.presentation.dto.request.DuplicateRequest;
 import com.handong.rebon.member.presentation.dto.request.MemberCreateRequest;
 import com.handong.rebon.member.presentation.dto.request.MemberUpdateRequest;
 import com.handong.rebon.member.presentation.dto.response.MemberCreateResponse;
@@ -35,13 +36,6 @@ public class ApiMemberController {
                              .body(MemberCreateResponse.from(response));
     }
 
-    @PostMapping("/members/nickname/check-duplicate")
-    public ResponseEntity<Void> nicknameDuplicateCheck(@RequestBody String nickname) {
-        memberService.checkNicknameDuplicate(nickname);
-        return ResponseEntity.ok()
-                             .build();
-    }
-
     @RequiredLogin
     @PatchMapping("/members")
     public ResponseEntity<Void> update(
@@ -51,6 +45,13 @@ public class ApiMemberController {
         MemberUpdateRequestDto memberUpdateRequestDto = MemberAssembler.memberUpdateRequestDto(loginMember.getId(), memberUpdateRequest);
         memberService.update(memberUpdateRequestDto);
 
+        return ResponseEntity.ok()
+                             .build();
+    }
+
+    @PostMapping("/members/nickname/check-duplicate")
+    public ResponseEntity<Void> nicknameDuplicateCheck(@RequestBody DuplicateRequest duplicateRequest) {
+        memberService.checkNicknameDuplicate(duplicateRequest.getNickname());
         return ResponseEntity.ok()
                              .build();
     }

--- a/backend/src/main/java/com/handong/rebon/member/presentation/dto/request/DuplicateRequest.java
+++ b/backend/src/main/java/com/handong/rebon/member/presentation/dto/request/DuplicateRequest.java
@@ -1,0 +1,12 @@
+package com.handong.rebon.member.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DuplicateRequest {
+    private String nickname;
+}

--- a/backend/src/test/java/com/handong/rebon/acceptance/member/MemberCreateAcceptanceTest.java
+++ b/backend/src/test/java/com/handong/rebon/acceptance/member/MemberCreateAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.handong.rebon.acceptance.member;
 
 import com.handong.rebon.acceptance.AcceptanceTest;
+import com.handong.rebon.member.presentation.dto.request.DuplicateRequest;
 import com.handong.rebon.member.presentation.dto.request.MemberCreateRequest;
 
 import org.springframework.http.HttpStatus;
@@ -42,8 +43,9 @@ public class MemberCreateAcceptanceTest extends AcceptanceTest {
     void checkDidNotDuplicateNickname() {
         //given
         String nickname = "ReBoN";
+        DuplicateRequest duplicateRequest = new DuplicateRequest(nickname);
         //when
-        ExtractableResponse<Response> response = checkDuplicateNickname(nickname);
+        ExtractableResponse<Response> response = checkDuplicateNickname(duplicateRequest);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -54,16 +56,17 @@ public class MemberCreateAcceptanceTest extends AcceptanceTest {
     void checkDuplicatedNickname() {
         //given
         String nickname = "test";
+        DuplicateRequest duplicateRequest = new DuplicateRequest(nickname);
         saveMember(new MemberCreateRequest("test@gmail.com", nickname, "google", true));
 
         //when
-        ExtractableResponse<Response> response = checkDuplicateNickname(nickname);
+        ExtractableResponse<Response> response = checkDuplicateNickname(duplicateRequest);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    private ExtractableResponse<Response> checkDuplicateNickname(String nickname) {
+    private ExtractableResponse<Response> checkDuplicateNickname(DuplicateRequest nickname) {
         return RestAssured.given(getRequestSpecification())
                           .log().all()
                           .contentType(APPLICATION_JSON_VALUE)


### PR DESCRIPTION
### Description
- 닉네임 중복 체크시 200OK만 보내는 bug 해결
- CORS localhost:3000 열어주기
- naver callback uri 변경

### Trouble Shooting


### ETC
